### PR TITLE
Added type parameter in call to "assertExchange" in Service.prototype…

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -183,8 +183,8 @@ Service.prototype.connect = co.wrap(function* connect(){
 
 		// Create the callback queue and exchanges
 		yield channel.assertQueue(cbq, {durable:true, exclusive:true})
-		yield channel.assertExchange(opts.exchangeDirect)
-		yield channel.assertExchange(opts.exchangeTopic)
+		yield channel.assertExchange(opts.exchangeDirect, 'direct')
+		yield channel.assertExchange(opts.exchangeTopic, 'topic')
 
 		// Prefetch and consume the callback queue
 		channel.prefetch(1)


### PR DESCRIPTION
…rvice.prototype.connect
Tests run successfully for me after removing the "events" exchange in rabbitmq. That exchange was creating as a "direct" type instead of a "topic."